### PR TITLE
Upgrade protocol and plugin version; Upgrade dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ Ensure all these dependencies are correctly set up and configured before attempt
 
 - **Run the Packaged JAR**
   - Once the JAR file is created, you can run the project using the Java command.
-  - Use the following command to run the packaged application: `java -jar target/cmb-plugin-10.1.0-SNAPSHOT.jar`. The package version specified in pom.xml , so if the user changes the version in pom.xml the package name will change.
+  - Use the following command to run the packaged application: `java -jar target/cmb-plugin-11.0.0-SNAPSHOT.jar`. The package version specified in pom.xml , so if the user changes the version in pom.xml the package name will change.

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <java.version>21</java.version>
-        <camino-messenger-protocol.protobuff.version>24.0.0.1.20250307104026.ffe2c3741a33</camino-messenger-protocol.protobuff.version>
-        <camino-messenger-protocol.grpc.version>1.58.0.1.20250307104026.ffe2c3741a33</camino-messenger-protocol.grpc.version>
+        <camino-messenger-protocol.protobuff.version>30.1.0.1.20250307104026.ffe2c3741a33</camino-messenger-protocol.protobuff.version>
+        <camino-messenger-protocol.grpc.version>1.71.0.1.20250307104026.ffe2c3741a33</camino-messenger-protocol.grpc.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
-            <version>1.68.1</version>
+            <version>1.71.0</version>
         </dependency>
 
         <!-- For the server (only) -->
@@ -70,6 +70,14 @@
             <artifactId>caffeine</artifactId>
             <version>3.1.8</version>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>4.30.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -11,15 +11,15 @@
     </parent>
     <groupId>com.chain4travel</groupId>
     <artifactId>cmb-plugin</artifactId>
-    <version>10.1.0-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <name>cmb-plugin</name>
     <description>cmb-plugin</description>
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <java.version>21</java.version>
-        <camino-messenger-protocol.protobuff.version>24.0.0.1.20240924170438.a97744087df6</camino-messenger-protocol.protobuff.version>
-        <camino-messenger-protocol.grpc.version>1.58.0.1.20240924170438.a97744087df6</camino-messenger-protocol.grpc.version>
+        <camino-messenger-protocol.protobuff.version>24.0.0.1.20250307104026.ffe2c3741a33</camino-messenger-protocol.protobuff.version>
+        <camino-messenger-protocol.grpc.version>1.58.0.1.20250307104026.ffe2c3741a33</camino-messenger-protocol.grpc.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/src/main/java/com/chain4travel/cmbplugin/cache/CacheService.java
+++ b/src/main/java/com/chain4travel/cmbplugin/cache/CacheService.java
@@ -1,13 +1,13 @@
 package com.chain4travel.cmbplugin.cache;
 
-import build.buf.gen.cmp.services.accommodation.v1.AccommodationSearchRequest;
-import build.buf.gen.cmp.services.accommodation.v1.AccommodationSearchResponse;
-import build.buf.gen.cmp.services.book.v1.ValidationRequest;
-import build.buf.gen.cmp.services.book.v1.ValidationResponse;
+import build.buf.gen.cmp.services.accommodation.v3.AccommodationSearchRequest;
+import build.buf.gen.cmp.services.accommodation.v3.AccommodationSearchResponse;
+import build.buf.gen.cmp.services.book.v2.ValidationRequest;
+import build.buf.gen.cmp.services.book.v2.ValidationResponse;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
-import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.Message;
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.io.InputStream;
@@ -172,8 +172,8 @@ public class CacheService {
       UUID id,
       CacheDataType cacheDataType,
       CacheSearchType cacheSearchType,
-      GeneratedMessageV3 requestMessage,
-      GeneratedMessageV3 responseMessage) {
+      Message requestMessage,
+      Message responseMessage) {
     var requestPath = getDataPath(id, cacheDataType, CacheDataContentType.request);
     var responsePath = getDataPath(id, cacheDataType, CacheDataContentType.response);
     var fileWriteSuccessful = false;

--- a/src/main/java/com/chain4travel/cmbplugin/grpc/converter/MessageConverter.java
+++ b/src/main/java/com/chain4travel/cmbplugin/grpc/converter/MessageConverter.java
@@ -1,11 +1,11 @@
 package com.chain4travel.cmbplugin.grpc.converter;
 
-import build.buf.gen.cmp.services.accommodation.v1.AccommodationSearchRequest;
-import build.buf.gen.cmp.services.accommodation.v1.AccommodationSearchResponse;
-import build.buf.gen.cmp.services.book.v1.ValidationRequest;
-import build.buf.gen.cmp.services.book.v1.ValidationResponse;
-import build.buf.gen.cmp.services.transport.v1.TransportSearchRequest;
-import build.buf.gen.cmp.services.transport.v1.TransportSearchResponse;
+import build.buf.gen.cmp.services.accommodation.v3.AccommodationSearchRequest;
+import build.buf.gen.cmp.services.accommodation.v3.AccommodationSearchResponse;
+import build.buf.gen.cmp.services.book.v2.ValidationRequest;
+import build.buf.gen.cmp.services.book.v2.ValidationResponse;
+import build.buf.gen.cmp.services.transport.v3.TransportSearchRequest;
+import build.buf.gen.cmp.services.transport.v3.TransportSearchResponse;
 import java.io.IOException;
 import java.io.InputStream;
 

--- a/src/main/java/com/chain4travel/cmbplugin/grpc/services/AccommodationSearchImpl.java
+++ b/src/main/java/com/chain4travel/cmbplugin/grpc/services/AccommodationSearchImpl.java
@@ -38,7 +38,7 @@ public class AccommodationSearchImpl
                 SearchResponseMetadata.newBuilder()
                     .setSearchId(
                         build.buf.gen.cmp.types.v1.UUID.newBuilder().setValue(searchId.toString()))
-                    .setContext("Hello from Spring Boot grpc partner plugin!"))
+                    .setContext("Accommodation search response from plugin"))
             .build();
 
     // If legacy system is not stateful, store data in cache for later validation

--- a/src/main/java/com/chain4travel/cmbplugin/grpc/services/AccommodationSearchImpl.java
+++ b/src/main/java/com/chain4travel/cmbplugin/grpc/services/AccommodationSearchImpl.java
@@ -2,10 +2,10 @@ package com.chain4travel.cmbplugin.grpc.services;
 
 import static com.chain4travel.cmbplugin.grpc.metadata.MetadataInterceptor.*;
 
-import build.buf.gen.cmp.services.accommodation.v1.AccommodationSearchRequest;
-import build.buf.gen.cmp.services.accommodation.v1.AccommodationSearchResponse;
-import build.buf.gen.cmp.services.accommodation.v1.AccommodationSearchServiceGrpc;
-import build.buf.gen.cmp.types.v1.SearchResponseMetadata;
+import build.buf.gen.cmp.services.accommodation.v3.AccommodationSearchRequest;
+import build.buf.gen.cmp.services.accommodation.v3.AccommodationSearchResponse;
+import build.buf.gen.cmp.services.accommodation.v3.AccommodationSearchServiceGrpc;
+import build.buf.gen.cmp.types.v3.SearchResponseMetadata;
 import com.chain4travel.cmbplugin.cache.CacheSearchType;
 import com.chain4travel.cmbplugin.cache.CacheService;
 import io.grpc.stub.StreamObserver;

--- a/src/main/java/com/chain4travel/cmbplugin/grpc/services/ActivitySearchImpl.java
+++ b/src/main/java/com/chain4travel/cmbplugin/grpc/services/ActivitySearchImpl.java
@@ -15,7 +15,9 @@ public class ActivitySearchImpl extends ActivitySearchServiceGrpc.ActivitySearch
     ActivitySearchResponse response =
         ActivitySearchResponse.newBuilder()
             .setMetadata(
-                SearchResponseMetadata.newBuilder().setContext("Activity search response").build())
+                SearchResponseMetadata.newBuilder()
+                    .setContext("Activity search response from plugin")
+                    .build())
             .build();
     responseObserver.onNext(response);
     responseObserver.onCompleted();

--- a/src/main/java/com/chain4travel/cmbplugin/grpc/services/ActivitySearchImpl.java
+++ b/src/main/java/com/chain4travel/cmbplugin/grpc/services/ActivitySearchImpl.java
@@ -1,9 +1,9 @@
 package com.chain4travel.cmbplugin.grpc.services;
 
-import build.buf.gen.cmp.services.activity.v1.ActivitySearchRequest;
-import build.buf.gen.cmp.services.activity.v1.ActivitySearchResponse;
-import build.buf.gen.cmp.services.activity.v1.ActivitySearchServiceGrpc;
-import build.buf.gen.cmp.types.v1.SearchResponseMetadata;
+import build.buf.gen.cmp.services.activity.v3.ActivitySearchRequest;
+import build.buf.gen.cmp.services.activity.v3.ActivitySearchResponse;
+import build.buf.gen.cmp.services.activity.v3.ActivitySearchServiceGrpc;
+import build.buf.gen.cmp.types.v3.SearchResponseMetadata;
 import io.grpc.stub.StreamObserver;
 import net.devh.boot.grpc.server.service.GrpcService;
 

--- a/src/main/java/com/chain4travel/cmbplugin/grpc/services/MintServiceImpl.java
+++ b/src/main/java/com/chain4travel/cmbplugin/grpc/services/MintServiceImpl.java
@@ -1,10 +1,10 @@
 package com.chain4travel.cmbplugin.grpc.services;
 
-import build.buf.gen.cmp.services.book.v1.MintRequest;
-import build.buf.gen.cmp.services.book.v1.MintResponse;
-import build.buf.gen.cmp.services.book.v1.MintServiceGrpc.MintServiceImplBase;
-import build.buf.gen.cmp.services.book.v1.ValidationRequest;
-import build.buf.gen.cmp.services.book.v1.ValidationResponse;
+import build.buf.gen.cmp.services.book.v2.MintRequest;
+import build.buf.gen.cmp.services.book.v2.MintResponse;
+import build.buf.gen.cmp.services.book.v2.MintServiceGrpc.MintServiceImplBase;
+import build.buf.gen.cmp.services.book.v2.ValidationRequest;
+import build.buf.gen.cmp.services.book.v2.ValidationResponse;
 import com.chain4travel.cmbplugin.cache.CacheService;
 import com.chain4travel.cmbplugin.grpc.converter.MessageConverter;
 import io.grpc.stub.StreamObserver;
@@ -58,6 +58,7 @@ public class MintServiceImpl extends MintServiceImplBase {
   }
 
   private void mintAccommodation(UUID validationId) {
-    // TODO mint accommodation by handing over just the validation id to the legacy system
+    // TODO mint accommodation by handing over just the validation id to the legacy
+    // system
   }
 }

--- a/src/main/java/com/chain4travel/cmbplugin/grpc/services/MintServiceImpl.java
+++ b/src/main/java/com/chain4travel/cmbplugin/grpc/services/MintServiceImpl.java
@@ -5,8 +5,11 @@ import build.buf.gen.cmp.services.book.v2.MintResponse;
 import build.buf.gen.cmp.services.book.v2.MintServiceGrpc.MintServiceImplBase;
 import build.buf.gen.cmp.services.book.v2.ValidationRequest;
 import build.buf.gen.cmp.services.book.v2.ValidationResponse;
+import build.buf.gen.cmp.types.v2.Currency;
+import build.buf.gen.cmp.types.v2.Price;
 import com.chain4travel.cmbplugin.cache.CacheService;
 import com.chain4travel.cmbplugin.grpc.converter.MessageConverter;
+import com.google.protobuf.Empty;
 import io.grpc.stub.StreamObserver;
 import java.util.UUID;
 import net.devh.boot.grpc.server.service.GrpcService;
@@ -46,6 +49,13 @@ public class MintServiceImpl extends MintServiceImplBase {
         MintResponse.newBuilder()
             .setMintId(build.buf.gen.cmp.types.v1.UUID.newBuilder().setValue(mintId.toString()))
             .setValidationId(request.getValidationId())
+            .setPrice(
+                Price.newBuilder()
+                    .setCurrency(
+                        Currency.newBuilder().setNativeToken(Empty.getDefaultInstance()).build())
+                    .setValue("000")
+                    .setDecimals(2)
+                    .build())
             .build();
 
     responseObserver.onNext(response);

--- a/src/main/java/com/chain4travel/cmbplugin/grpc/services/TransportSearchImpl.java
+++ b/src/main/java/com/chain4travel/cmbplugin/grpc/services/TransportSearchImpl.java
@@ -1,9 +1,9 @@
 package com.chain4travel.cmbplugin.grpc.services;
 
-import build.buf.gen.cmp.services.transport.v1.TransportSearchRequest;
-import build.buf.gen.cmp.services.transport.v1.TransportSearchResponse;
-import build.buf.gen.cmp.services.transport.v1.TransportSearchServiceGrpc;
-import build.buf.gen.cmp.types.v1.SearchResponseMetadata;
+import build.buf.gen.cmp.services.transport.v3.TransportSearchRequest;
+import build.buf.gen.cmp.services.transport.v3.TransportSearchResponse;
+import build.buf.gen.cmp.services.transport.v3.TransportSearchServiceGrpc;
+import build.buf.gen.cmp.types.v3.SearchResponseMetadata;
 import io.grpc.stub.StreamObserver;
 import net.devh.boot.grpc.server.service.GrpcService;
 

--- a/src/main/java/com/chain4travel/cmbplugin/grpc/services/TransportSearchImpl.java
+++ b/src/main/java/com/chain4travel/cmbplugin/grpc/services/TransportSearchImpl.java
@@ -15,7 +15,9 @@ public class TransportSearchImpl extends TransportSearchServiceGrpc.TransportSea
     TransportSearchResponse response =
         TransportSearchResponse.newBuilder()
             .setMetadata(
-                SearchResponseMetadata.newBuilder().setContext("Transport search response").build())
+                SearchResponseMetadata.newBuilder()
+                    .setContext("Transport search response from plugin")
+                    .build())
             .build();
     responseObserver.onNext(response);
     responseObserver.onCompleted();

--- a/src/main/java/com/chain4travel/cmbplugin/grpc/services/ValidationServiceImpl.java
+++ b/src/main/java/com/chain4travel/cmbplugin/grpc/services/ValidationServiceImpl.java
@@ -1,10 +1,10 @@
 package com.chain4travel.cmbplugin.grpc.services;
 
-import build.buf.gen.cmp.services.accommodation.v1.AccommodationSearchRequest;
-import build.buf.gen.cmp.services.accommodation.v1.AccommodationSearchResponse;
-import build.buf.gen.cmp.services.book.v1.ValidationRequest;
-import build.buf.gen.cmp.services.book.v1.ValidationResponse;
-import build.buf.gen.cmp.services.book.v1.ValidationServiceGrpc.ValidationServiceImplBase;
+import build.buf.gen.cmp.services.accommodation.v3.AccommodationSearchRequest;
+import build.buf.gen.cmp.services.accommodation.v3.AccommodationSearchResponse;
+import build.buf.gen.cmp.services.book.v2.ValidationRequest;
+import build.buf.gen.cmp.services.book.v2.ValidationResponse;
+import build.buf.gen.cmp.services.book.v2.ValidationServiceGrpc.ValidationServiceImplBase;
 import com.chain4travel.cmbplugin.cache.CacheSearchType;
 import com.chain4travel.cmbplugin.cache.CacheService;
 import com.chain4travel.cmbplugin.grpc.converter.MessageConverter;


### PR DESCRIPTION
Followed instructions provided here
https://github.com/grpc/grpc-java/issues/11015#issuecomment-2560196695

Then, I upgraded to an even higher version (**4.30.1**) after encountering another issue with incompatibility.
No new Services were added.


### How this was tested
- Tested if old version services are not providing a response
Expected result:
`error calling partner plugin service: rpc error: code = Unimplemented desc = Method not found: cmp.services.accommodation.v1.AccommodationSearchService/AccommodationSearch`

- Tested if new version services are providing a response

Mint and Validate -> message is propagated but  `Price` is missing  in Mint -  fixed

**Validate and Mint will be tested one more time during the next PR**


